### PR TITLE
fix: add Cloudflare Worker proxy for API Origin header restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,46 @@ This is a Text-to-Speech browser extension that uses MS Edge Online TTS service.
 - User-friendly interface
 - Language and country autocomplete for fast search
 
+## ⚠️ Important: API Fix Required (December 2024)
+
+Microsoft recently tightened their API security, requiring a specific Origin header that browsers cannot set. This fix uses a Cloudflare Worker as a proxy.
+
+### Quick Setup
+
+1. **Deploy the proxy** (free, takes 2 minutes):
+   ```bash
+   npm install -g wrangler
+   wrangler login
+   cd cloudflare-worker && wrangler deploy
+   ```
+   You'll get a URL like `https://msedge-tts-proxy.YOUR_USERNAME.workers.dev`
+
+2. **Configure the extension**:
+   Edit `assets/custom hooks/useTTS.tsx` and replace `YOUR_USERNAME` with your Cloudflare username.
+
+3. **Build and install**:
+   ```bash
+   npm install
+   npm run build
+   ```
+
+See [cloudflare-worker/README.md](cloudflare-worker/README.md) for details.
+
+---
+
 ## Installation
 ### - Mozilla / Chrome Web Store
-- [Chrome Web Store](https://chrome.google.com/webstore/detail/oajalfneblkfiejoadecnmodfpnaeblh)
-- [Mozilla Addons](https://addons.mozilla.org/en-US/firefox/addon/ms-edge-tts-text-to-speech/)
+- [Chrome Web Store](https://chrome.google.com/webstore/detail/oajalfneblkfiejoadecnmodfpnaeblh) *(may be outdated)*
+- [Mozilla Addons](https://addons.mozilla.org/en-US/firefox/addon/ms-edge-tts-text-to-speech/) *(may be outdated)*
 ### - Manual Installation
 1. Clone this repository and run `npm i`.
-2. Run `npm run build` for Chrome, `npm run build:firefox` for Firefox.
-3. Open your browser's extension settings.
-4. Enable developer mode.
-5. Click on "Load unpacked" and select the extension folder.
-6. The extension should now be installed and ready to use.
+2. **Deploy the Cloudflare Worker proxy** (see above).
+3. Update `PROXY_URL` in `assets/custom hooks/useTTS.tsx`.
+4. Run `npm run build` for Chrome, `npm run build:firefox` for Firefox.
+5. Open your browser's extension settings.
+6. Enable developer mode.
+7. Click on "Load unpacked" and select the `.output/chrome-mv3` folder.
+8. The extension should now be installed and ready to use.
 
 ## Screenshots
 ![MsEdge_TTS_Screenshot_1.png](/screenshots/MsEdge_TTS_Screenshot_1.png)

--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -1,0 +1,72 @@
+# MS Edge TTS Proxy - Cloudflare Worker
+
+Microsoft recently tightened their API security, requiring a specific Origin header that browsers cannot set due to security restrictions. This Cloudflare Worker acts as a proxy to bypass this limitation.
+
+## Quick Deploy
+
+```bash
+# Install wrangler CLI
+npm install -g wrangler
+
+# Login to Cloudflare (free account)
+wrangler login
+
+# Deploy
+cd cloudflare-worker
+wrangler deploy
+```
+
+After deployment, you'll get a URL like `https://msedge-tts-proxy.YOUR_USERNAME.workers.dev`
+
+## Configure the Extension
+
+Update `PROXY_URL` in `assets/custom hooks/useTTS.tsx`:
+
+```typescript
+const PROXY_URL = 'https://msedge-tts-proxy.YOUR_USERNAME.workers.dev';
+```
+
+Then rebuild:
+
+```bash
+npm run build
+```
+
+## API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/health` | GET | Health check |
+| `/tts` | POST | Generate TTS audio |
+
+### POST /tts
+
+```json
+{
+  "text": "Text to convert",
+  "voice": "en-US-AriaNeural",
+  "rate": "+0%",
+  "pitch": "+0Hz",
+  "volume": "+0%"
+}
+```
+
+Returns: `audio/mpeg`
+
+## Free Tier
+
+Cloudflare Workers free plan includes 100,000 requests/day - more than enough for personal use.
+
+## How It Works
+
+Browser WebSocket API cannot set custom headers, but Microsoft's API validates the Origin header. Cloudflare Workers' fetch API supports WebSocket connections via HTTP Upgrade with custom headers, bypassing this limitation.
+
+```javascript
+const resp = await fetch(wsUrl, {
+  headers: {
+    'Upgrade': 'websocket',
+    'Origin': 'chrome-extension://jdiccldimpdaibmpdkjnbmckianbfold'
+  }
+});
+const ws = resp.webSocket;
+```

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -1,0 +1,202 @@
+/**
+ * Cloudflare Worker - MS Edge TTS Proxy
+ * Uses fetch-based WebSocket API to set custom Origin header
+ */
+
+const TRUSTED_CLIENT_TOKEN = "6A5AA1D4EAFF4E9FB37E23D68491D6F4";
+// Cloudflare fetch requires https:// instead of wss://
+const WSS_URL = "https://speech.platform.bing.com/consumer/speech/synthesize/readaloud/edge/v1";
+const SEC_MS_GEC_VERSION = "1-143.0.3650.75";
+
+function generateUUID() {
+  return 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'.replace(/x/g, () =>
+    Math.floor(Math.random() * 16).toString(16)
+  );
+}
+
+async function generateSecMsGec() {
+  const ticks = BigInt(Math.floor((Date.now() / 1000) + 11644473600) * 10000000);
+  const roundedTicks = ticks - (ticks % BigInt(3000000000));
+  const strToHash = roundedTicks.toString() + TRUSTED_CLIENT_TOKEN;
+
+  const data = new TextEncoder().encode(strToHash);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+    .toUpperCase();
+}
+
+function escapeXml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function buildSSML(text, voice, rate, pitch, volume) {
+  return `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'>
+    <voice name='${voice}'>
+      <prosody rate='${rate}' pitch='${pitch}' volume='${volume}'>
+        ${escapeXml(text)}
+      </prosody>
+    </voice>
+  </speak>`;
+}
+
+async function synthesize(text, voice, rate, pitch, volume) {
+  const reqId = generateUUID();
+  const secMsGEC = await generateSecMsGec();
+
+  const wsUrl = `${WSS_URL}?TrustedClientToken=${TRUSTED_CLIENT_TOKEN}&Sec-MS-GEC=${secMsGEC}&Sec-MS-GEC-Version=${SEC_MS_GEC_VERSION}&ConnectionId=${reqId}`;
+
+  // 使用 Cloudflare 的 fetch-based WebSocket API
+  const resp = await fetch(wsUrl, {
+    headers: {
+      'Upgrade': 'websocket',
+      'Origin': 'chrome-extension://jdiccldimpdaibmpdkjnbmckianbfold',
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36 Edg/143.0.0.0'
+    }
+  });
+
+  const ws = resp.webSocket;
+  if (!ws) {
+    throw new Error('WebSocket upgrade failed');
+  }
+
+  ws.accept();
+
+  const audioChunks = [];
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error('Timeout'));
+    }, 30000);
+
+    // 发送配置
+    const configMsg = `X-Timestamp:${new Date().toISOString()}\r\nContent-Type:application/json; charset=utf-8\r\nPath:speech.config\r\n\r\n{"context":{"synthesis":{"audio":{"metadataoptions":{"sentenceBoundaryEnabled":"false","wordBoundaryEnabled":"false"},"outputFormat":"audio-24khz-96kbitrate-mono-mp3"}}}}`;
+    ws.send(configMsg);
+
+    // 发送 SSML
+    const ssml = buildSSML(text, voice, rate, pitch, volume);
+    const ssmlMsg = `X-RequestId:${reqId}\r\nContent-Type:application/ssml+xml\r\nX-Timestamp:${new Date().toISOString()}\r\nPath:ssml\r\n\r\n${ssml}`;
+    ws.send(ssmlMsg);
+
+    ws.addEventListener('message', async (event) => {
+      const data = event.data;
+
+      if (typeof data === 'string') {
+        if (data.includes('Path:turn.end')) {
+          clearTimeout(timeout);
+          ws.close();
+
+          // 合并音频
+          const totalLen = audioChunks.reduce((a, c) => a + c.byteLength, 0);
+          const result = new Uint8Array(totalLen);
+          let offset = 0;
+          for (const chunk of audioChunks) {
+            result.set(new Uint8Array(chunk), offset);
+            offset += chunk.byteLength;
+          }
+          resolve(result);
+        }
+      } else {
+        // 二进制音频数据
+        const arrayBuffer = data instanceof ArrayBuffer ? data : await data.arrayBuffer();
+        const bytes = new Uint8Array(arrayBuffer);
+
+        // 查找 "Path:audio\r\n" 分隔符
+        const separator = new TextEncoder().encode("Path:audio\r\n");
+        let audioStart = -1;
+
+        for (let i = 0; i <= bytes.length - separator.length; i++) {
+          let found = true;
+          for (let j = 0; j < separator.length; j++) {
+            if (bytes[i + j] !== separator[j]) {
+              found = false;
+              break;
+            }
+          }
+          if (found) {
+            audioStart = i + separator.length;
+            break;
+          }
+        }
+
+        if (audioStart > 0) {
+          audioChunks.push(bytes.slice(audioStart).buffer);
+        }
+      }
+    });
+
+    ws.addEventListener('error', (e) => {
+      clearTimeout(timeout);
+      reject(new Error('WebSocket error'));
+    });
+
+    ws.addEventListener('close', () => {
+      clearTimeout(timeout);
+    });
+  });
+}
+
+function corsHeaders() {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  };
+}
+
+export default {
+  async fetch(request) {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: corsHeaders() });
+    }
+
+    const url = new URL(request.url);
+
+    // 健康检查
+    if (url.pathname === '/' || url.pathname === '/health') {
+      return new Response(JSON.stringify({ status: 'ok' }), {
+        headers: { ...corsHeaders(), 'Content-Type': 'application/json' }
+      });
+    }
+
+    // TTS 端点
+    if (url.pathname === '/tts' && request.method === 'POST') {
+      try {
+        const { text, voice, rate, pitch, volume } = await request.json();
+
+        if (!text?.trim()) {
+          return new Response(JSON.stringify({ error: 'Text required' }), {
+            status: 400,
+            headers: { ...corsHeaders(), 'Content-Type': 'application/json' }
+          });
+        }
+
+        const audio = await synthesize(
+          text,
+          voice || 'en-US-AndrewNeural',
+          rate || '+0%',
+          pitch || '+0Hz',
+          volume || '+0%'
+        );
+
+        return new Response(audio, {
+          headers: { ...corsHeaders(), 'Content-Type': 'audio/mpeg' }
+        });
+      } catch (e) {
+        return new Response(JSON.stringify({ error: e.message }), {
+          status: 500,
+          headers: { ...corsHeaders(), 'Content-Type': 'application/json' }
+        });
+      }
+    }
+
+    return new Response('Not Found', { status: 404, headers: corsHeaders() });
+  }
+};

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -1,0 +1,3 @@
+name = "msedge-tts-proxy"
+main = "worker.js"
+compatibility_date = "2024-01-01"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^7.0.2",
         "@mui/material": "^7.0.2",
+        "edge-tts-universal": "^1.3.3",
         "msedge-tts": "^2.0.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -104,7 +105,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -472,7 +472,6 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -513,7 +512,6 @@
       "version": "11.14.1",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1061,7 +1059,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.2.0.tgz",
       "integrity": "sha512-NTuyFNen5Z2QY+I242MDZzXnFIVIR6ERxo7vntFi9K1wCgSwvIl0HcAO2OOydKqqKApE6omRiYhpny1ZhGuH7Q==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6",
         "@mui/core-downloads-tracker": "^7.2.0",
@@ -1753,7 +1750,6 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1889,6 +1885,15 @@
       "dev": true,
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-align": {
@@ -2394,7 +2399,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3280,6 +3284,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3682,6 +3695,38 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/edge-tts-universal": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/edge-tts-universal/-/edge-tts-universal-1.3.3.tgz",
+      "integrity": "sha512-jlUvYGsJ+o93FRPWQDQa/E7jqYbuLJAKKq9qvylo0/yHE1vtp4HCSzSAamviBewmpaNHlEJm+eEMimJXfu98zw==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "axios": "^1.12.1",
+        "cross-fetch": "^4.1.0",
+        "https-proxy-agent": "^7.0.6",
+        "isomorphic-ws": "^5.0.0",
+        "uuid": "^11.1.0",
+        "ws": "^8.18.3",
+        "xml-escape": "^1.1.0"
+      },
+      "engines": {
+        "node": "^18.17 || ^20.9 || >=22",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/edge-tts-universal/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4569,6 +4614,19 @@
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
       "dev": true
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/human-signals": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
@@ -5324,7 +5382,6 @@
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
       "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.25.4",
         "@babel/types": "^7.25.4",
@@ -5620,6 +5677,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-fetch-native": {
@@ -6924,7 +7001,6 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6933,7 +7009,6 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7115,7 +7190,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.2.tgz",
       "integrity": "sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7863,7 +7937,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7945,6 +8018,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -8239,7 +8318,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8366,7 +8444,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8485,11 +8562,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/when": {
       "version": "3.7.7",
@@ -8582,10 +8675,10 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
-      "peer": true,
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8607,7 +8700,6 @@
       "resolved": "https://registry.npmjs.org/wxt/-/wxt-0.20.7.tgz",
       "integrity": "sha512-KABq5i3CnXMUaJTcORGDLCi04K/IceUVAx5rler2QbZpLvS13OUOO0k+4s/7LI3+N8zXLh/GlQArMyJfk3M2yQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@1natsu/wait-element": "^4.1.2",
         "@aklinker1/rollup-plugin-visualizer": "5.12.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.0.2",
     "@mui/material": "^7.0.2",
+    "edge-tts-universal": "^1.3.3",
     "msedge-tts": "^2.0.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",


### PR DESCRIPTION
## Problem
Microsoft tightened their API security in December 2024. The TTS API now validates the `Origin` header, which browsers cannot set for WebSocket connections due to security restrictions. This breaks the extension for all users.

Related issue: #65 #66

## Solution
Add a Cloudflare Worker proxy that:
- Accepts requests from the extension
- Forwards them to Microsoft's API with the correct `Origin` header
- Returns the audio response

## Changes
- Add `cloudflare-worker/` directory with proxy code
- Update `useTTS.tsx` to use the proxy endpoint
- Update README with setup instructions

## Setup Required
Users need to deploy their own Cloudflare Worker (free tier, 100k requests/day). See `cloudflare-worker/README.md` for instructions.
